### PR TITLE
[DVT-701] Implementa análise incremental do CodeNarc com filtro de arquivos específicos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codenarc/codenarc:latest
+FROM codenarc/codenarc:3.6.0-groovy3.0.23
 
 RUN DEBIAN_FRONTEND=noninteractive \
 apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codenarc/codenarc:2.2.0-groovy3.0.8
+FROM codenarc/codenarc:latest
 
 RUN DEBIAN_FRONTEND=noninteractive \
 apt-get update && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ -n "${GITHUB_WORKSPACE}" ] ; then
   cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
-  
+
   git config --global --add safe.directory "$GITHUB_WORKSPACE" || exit
 fi
 
@@ -13,14 +13,15 @@ if [ -n "$INPUT_SOURCE_FILES" ]; then
   java -jar /lib/codenarc-all.jar \
       -report="${INPUT_REPORT:-compact:stdout}" \
       -rulesetfiles="${INPUT_RULESETFILES}" \
-      -files="${INPUT_SOURCE_FILES}" \
+      -basedir="." \
+      -includes="${INPUT_SOURCE_FILES}" \
       > result.txt
+  cat result.txt
 else
-  java -jar /lib/codenarc-all.jar \
-      -report="${INPUT_REPORT:-compact:stdout}" \
-      -rulesetfiles="${INPUT_RULESETFILES}" \
-      > result.txt
+  echo "Nenhum arquivo Groovy alterado encontrado. Pulando análise do CodeNarc."
+  exit 0
 fi
+
 
 < result.txt reviewdog -efm="%f:%l:%m" -efm="%f:%r:%m" \
     -name="codenarc" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,6 @@ set -e
 
 if [ -n "${GITHUB_WORKSPACE}" ] ; then
   cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
-
   git config --global --add safe.directory "$GITHUB_WORKSPACE" || exit
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,5 +30,3 @@ fi
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     ${INPUT_REVIEWDOG_FLAGS}
-
-rm result.txt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,10 @@ if [ -n "$INPUT_SOURCE_FILES" ]; then
       -includes="${INPUT_SOURCE_FILES}" \
       > result.txt
 else
-  echo "Nenhum arquivo Groovy alterado encontrado. Pulando análise do CodeNarc."
-  exit 0
+  java -jar /lib/codenarc-all.jar \
+      -report="${INPUT_REPORT:-compact:stdout}" \
+      -rulesetfiles="${INPUT_RULESETFILES}" \
+      > result.txt
 fi
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,18 @@ fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-java -jar /lib/codenarc-all.jar \
-    -report="${INPUT_REPORT:-compact:stdout}" \
-    -rulesetfiles="${INPUT_RULESETFILES}" \
-    > result.txt
+if [ -n "$INPUT_SOURCE_FILES" ]; then
+  java -jar /lib/codenarc-all.jar \
+      -report="${INPUT_REPORT:-compact:stdout}" \
+      -rulesetfiles="${INPUT_RULESETFILES}" \
+      -files="${INPUT_SOURCE_FILES}" \
+      > result.txt
+else
+  java -jar /lib/codenarc-all.jar \
+      -report="${INPUT_REPORT:-compact:stdout}" \
+      -rulesetfiles="${INPUT_RULESETFILES}" \
+      > result.txt
+fi
 
 < result.txt reviewdog -efm="%f:%l:%m" -efm="%f:%r:%m" \
     -name="codenarc" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,7 +16,6 @@ if [ -n "$INPUT_SOURCE_FILES" ]; then
       -basedir="." \
       -includes="${INPUT_SOURCE_FILES}" \
       > result.txt
-  cat result.txt
 else
   echo "Nenhum arquivo Groovy alterado encontrado. Pulando análise do CodeNarc."
   exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,3 +28,5 @@ fi
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     ${INPUT_REVIEWDOG_FLAGS}
+
+rm result.txt


### PR DESCRIPTION
### Impacto

Este PR tem como objetivo implementar uma análise incremental do CodeNarc que processa apenas os arquivos Groovy especificados ao invés de analisar todo o projeto. A mudança adiciona uma verificação condicional da variável `INPUT_SOURCE_FILES` que, quando definida, utiliza o parâmetro `-includes` para limitar a análise apenas aos arquivos alterados, resultando em execuções mais rápidas e eficientes. Quando não há arquivos Groovy para analisar, o processo termina sem executar a análise desnecessariamente, otimizando recursos computacionais e tempo de execução em pipelines de CI/CD.

### Link da tarefa no JIRA

https://asaasdev.atlassian.net/browse/DVT-707

### Cenários testados

Realizado diversos testes das regras do CodeNarc utilizando um [PR de teste](https://github.com/asaasdev/asaas/pull/51880), foram observados o devido comportamento das análises do CodeNarc.