### PR TITLE
feat: reabilita bloqueio de merge para violacoes em codigo alterado

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -217,9 +217,9 @@ check_blocking_rules() {
   done
   
   if [ "$(cat "$VIOLATIONS_FLAG")" -eq 1 ]; then
-    echo "⛔ P1s existem E há violações em linhas alteradas → DEVERIA bloquear merge"
-    echo "🔧 Exit desabilitado temporariamente para monitoramento"
-    # exit 1
+    echo "⛔ P1s existem E há violações em linhas alteradas"
+    echo "💡 Corrija as violacoes ou use o bypass autorizado pelo coordenador."
+    exit 1
   else
     echo "✅ P1s existem mas fora das linhas alteradas → merge permitido"
   fi


### PR DESCRIPTION
### Impacto

Reabilitado o bloqueio de merge no codenarc-docker após período de monitoramento e validação.

Antes: Exit estava desabilitado temporariamente (# exit 1) apenas logando que "DEVERIA bloquear merge"
Agora: Exit reabilitado (exit 1) efetivamente bloqueando merge quando há P1s em linhas alteradas

### Cenários testados

Funcionalidade já validada no PR anterior com 5 cenários de teste. Esta mudança apenas:

✅ Reabilita o exit 1 que estava comentado

✅ Mantém toda lógica de detecção inteligente inalterada

✅ Preserva comentários do reviewdog funcionando normalmente