### PR TITLE
feat(DVT-1005): corrige falsos positivos e exibe priority das violacoes CodeNarc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,24 @@
-FROM codenarc/codenarc:3.6.0-groovy3.0.23
+# Build CodeNarc from source
+FROM gradle:8.5-jdk17 AS builder
+
+WORKDIR /build
+RUN git clone https://github.com/CodeNarc/CodeNarc.git && \
+    cd CodeNarc && \
+    git checkout master && \
+    ./gradlew shadowJar && \
+    ls -la build/libs/
+
+# Runtime image
+FROM eclipse-temurin:11-jre-jammy
 
 RUN DEBIAN_FRONTEND=noninteractive \
-apt-get update && \
-apt-get install --no-install-recommends -y wget git && \
-apt-get clean && rm -rf /var/lib/apt/lists/* 
+    apt-get update && \
+    apt-get install --no-install-recommends -y wget git jq && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV REVIEWDOG_VERSION=v0.13.0
+COPY --from=builder /build/CodeNarc/build/libs/CodeNarc-*.jar /lib/codenarc-all.jar
+
+ENV REVIEWDOG_VERSION=v0.20.3
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,16 @@
-# Build CodeNarc from source
-FROM gradle:8.5-jdk17 AS builder
-
-WORKDIR /build
-RUN git clone https://github.com/CodeNarc/CodeNarc.git && \
-    cd CodeNarc && \
-    git checkout master && \
-    ./gradlew shadowJar && \
-    ls -la build/libs/
-
-# Runtime image
-FROM eclipse-temurin:11-jre-jammy
+FROM codenarc/codenarc:3.6.0-groovy3.0.23
 
 RUN DEBIAN_FRONTEND=noninteractive \
     apt-get update && \
     apt-get install --no-install-recommends -y wget git jq && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /build/CodeNarc/build/libs/CodeNarc-*.jar /lib/codenarc-all.jar
-
-ENV REVIEWDOG_VERSION=v0.20.3
+ENV REVIEWDOG_VERSION=v0.13.0
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
+RUN wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b /usr/local/bin/ ${REVIEWDOG_VERSION}
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -196,8 +196,7 @@ check_blocking_rules() {
   cat "$CHANGED_FILES_CACHE" 2>/dev/null || echo "(cache vazio)"
   echo ""
 
-  blocking_found=0
-  echo "$p1_violations" | while IFS=: read -r file line rest; do
+  while IFS=: read -r file line rest; do
     [ -z "$file" ] && continue
     file_matches_filter "$file" || continue
 
@@ -206,23 +205,21 @@ check_blocking_rules() {
     if [ -z "$line" ]; then
       if is_changed "$file" ""; then
         echo "⛔ $file (file-level): $rest"
-        blocking_found=1
-        break
+        echo ""
+        echo "💡 Corrija as violações ou use o bypass autorizado."
+        exit 1
       fi
     else
       if is_changed "$file" "$line"; then
         echo "⛔ $file:$line: $rest"
-        blocking_found=1
-        break
+        echo ""
+        echo "💡 Corrija as violações ou use o bypass autorizado."
+        exit 1
       fi
     fi
-  done
-
-  if [ "$blocking_found" -eq 1 ]; then
-    echo ""
-    echo "💡 Corrija as violações ou use o bypass autorizado."
-    exit 1
-  fi
+  done <<EOF
+$p1_violations
+EOF
 
   echo "✅ P1s existem mas fora das linhas alteradas → merge permitido"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -316,8 +316,7 @@ check_blocking_rules() {
 }
 
 if [ -n "${GITHUB_WORKSPACE}" ]; then
-  cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
-  git config --global --add safe.directory "$GITHUB_WORKSPACE"
+  git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
 fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,7 +109,11 @@ build_changed_lines_cache() {
     /^@@/ {
       match($0, /\+([0-9]+)(,([0-9]+))?/, arr)
       start = arr[1]
-      count = (arr[3] != "" ? arr[3] : 1)
+      if (arr[3] == "") {
+        count = 1
+      } else {
+        count = arr[3]
+      }
       for (i = start; i < start + count; i++)
         print file ":" i > "/tmp/changed_lines.txt"
     }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -210,20 +210,28 @@ check_blocking_rules() {
     file_matches_filter "$file" || continue
 
     echo "🔍 Verificando: $file:$line"
+    echo "   Debug - file='$file' line='$line'"
     
     if [ -z "$line" ]; then
+      echo "   → File-based violation"
       if is_changed "$file" ""; then
         echo "⛔ $file (file-level): $rest"
         echo ""
         found_blocking=1
         break
+      else
+        echo "   → Arquivo não está no diff"
       fi
     else
+      echo "   → Line-based violation"
+      echo "   → Procurando por: '${file}:${line}'"
       if is_changed "$file" "$line"; then
         echo "⛔ $file:$line: $rest"
         echo ""
         found_blocking=1
         break
+      else
+        echo "   → Linha não está no diff"
       fi
     fi
   done <<EOF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,15 +105,19 @@ build_changed_lines_cache() {
   [ ! -s "$ALL_DIFF" ] && return
 
   awk '
-    /^diff --git/ { file = $3; sub(/^a\//, "", file); print file > "/tmp/changed_files.txt" }
+    /^diff --git/ {
+      file = $3
+      sub(/^a\//, "", file)
+      print file > "/tmp/changed_files.txt"
+    }
     /^@@/ {
-      match($0, /\+([0-9]+)(,([0-9]+))?/, arr)
-      start = arr[1]
-      if (arr[3] == "") {
-        count = 1
-      } else {
-        count = arr[3]
-      }
+      match($0, /\+([0-9]+)(,([0-9]+))?/)
+      range = substr($0, RSTART, RLENGTH)
+      sub(/^\+/, "", range)
+      split(range, parts, ",")
+      start = parts[1]
+      count = parts[2]
+      if (count == "") count = 1
       for (i = start; i < start + count; i++)
         print file ":" i > "/tmp/changed_lines.txt"
     }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ run_codenarc() {
   includes_arg=""
   [ -n "$INPUT_SOURCE_FILES" ] && includes_arg="-includes=${INPUT_SOURCE_FILES}"
   
+  echo ""
   echo "🔍 Executando CodeNarc para análise estática..."
   java -jar /lib/codenarc-all.jar \
     -report="json:${CODENARC_JSON}" \
@@ -25,6 +26,7 @@ run_codenarc() {
     -basedir="." \
     $includes_arg >/dev/null 2>&1
   
+  echo ""
   echo "📋 Processando violações encontradas:"
   convert_json_to_compact
   cat "$CODENARC_COMPACT"
@@ -50,6 +52,7 @@ convert_json_to_compact() {
 
 run_reviewdog() {
   [ ! -s "$CODENARC_COMPACT" ] && return
+  echo ""
   echo "📤 Enviando resultados para reviewdog..."
   
   if [ "${INPUT_REPORTER}" = "local" ]; then
@@ -154,6 +157,7 @@ extract_p1_violations() {
 }
 
 check_blocking_rules() {
+  echo ""
   echo "🔎 Verificando violações bloqueantes (P1)..."
   [ ! -f "$CODENARC_JSON" ] && echo "❌ Erro: Resultado do CodeNarc não encontrado. Não é possível verificar P1s." && return 1
   
@@ -167,18 +171,20 @@ check_blocking_rules() {
   echo "📊 Total de P1 encontradas: $p1_count"
   echo "⛔ Violações P1:"
   echo "$p1_violations"
-  echo ""
 
   if [ "${INPUT_REPORTER}" = "local" ]; then
+    echo ""
     echo "🏠 Modo de execução local: todas as violações P1 são bloqueantes."
     echo "💡 Corrija as violações antes de prosseguir."
     exit 1
   fi
 
+  echo ""
   echo "⚠️  Analisando se as P1s estão em linhas alteradas..."
   build_changed_lines_cache
 
   if [ ! -s "$ALL_DIFF" ]; then
+    echo ""
     echo "⚠️  Diff vazio: Sem informações de linhas alteradas. Todas as P1s são consideradas bloqueantes."
     echo "💡 Corrija as violações ou use um bypass autorizado."
     exit 1
@@ -212,6 +218,7 @@ EOF
     exit 1
   fi
 
+  echo ""
   echo "✅ Todas as violações P1 estão fora das linhas alteradas → merge permitido"
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -196,23 +196,33 @@ check_blocking_rules() {
   cat "$CHANGED_FILES_CACHE" 2>/dev/null || echo "(cache vazio)"
   echo ""
 
+  blocking_found=0
   echo "$p1_violations" | while IFS=: read -r file line rest; do
     [ -z "$file" ] && continue
     file_matches_filter "$file" || continue
 
     echo "🔍 Verificando: $file:$line"
-
+    
     if [ -z "$line" ]; then
-      is_changed "$file" "" && echo "⛔ $file (file-level): $rest" && exit 1
+      if is_changed "$file" ""; then
+        echo "⛔ $file (file-level): $rest"
+        blocking_found=1
+        break
+      fi
     else
       if is_changed "$file" "$line"; then
         echo "⛔ $file:$line: $rest"
-        exit 1
+        blocking_found=1
+        break
       fi
     fi
   done
 
-  [ $? -eq 1 ] && echo "" && echo "💡 Corrija as violações ou use o bypass autorizado." && exit 1
+  if [ "$blocking_found" -eq 1 ]; then
+    echo ""
+    echo "💡 Corrija as violações ou use o bypass autorizado."
+    exit 1
+  fi
 
   echo "✅ P1s existem mas fora das linhas alteradas → merge permitido"
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,15 @@
 #!/bin/sh
 set -e
 
-CODENARC_SARIF="result.sarif.json"
-CODENARC_SARIF_LINE="result_line.sarif.json"
-CODENARC_SARIF_FILE="result_file.sarif.json"
+CODENARC_JSON="result.json"
 CODENARC_COMPACT="result.txt"
-LINE_VIOLATIONS="line_violations.txt"
-FILE_VIOLATIONS="file_violations.txt"
-VIOLATIONS_FLAG="/tmp/found_violations.txt"
 ALL_DIFF="/tmp/all_diff.txt"
 CHANGED_LINES_CACHE="/tmp/changed_lines.txt"
 CHANGED_FILES_CACHE="/tmp/changed_files.txt"
 
 cleanup_temp_files() {
-  rm -f "$CODENARC_SARIF" "$CODENARC_SARIF_LINE" "$CODENARC_SARIF_FILE" "$CODENARC_COMPACT" "$LINE_VIOLATIONS" "$FILE_VIOLATIONS" \
-        "$VIOLATIONS_FLAG" "$ALL_DIFF" "$CHANGED_LINES_CACHE" "$CHANGED_FILES_CACHE" \
-        "${FILE_VIOLATIONS}.formatted" >/dev/null 2>&1
+  rm -f "$CODENARC_JSON" "$CODENARC_COMPACT" "$ALL_DIFF" \
+        "$CHANGED_LINES_CACHE" "$CHANGED_FILES_CACHE" >/dev/null 2>&1
 }
 
 trap 'cleanup_temp_files' EXIT
@@ -26,117 +20,65 @@ run_codenarc() {
 
   echo "🔍 Executando CodeNarc..."
   java -jar /lib/codenarc-all.jar \
-    -report="sarif:${CODENARC_SARIF}" \
+    -report="json:${CODENARC_JSON}" \
     -rulesetfiles="${INPUT_RULESETFILES}" \
     -basedir="." \
     $includes_arg
 
-  convert_sarif_to_compact
-  split_sarif_by_type
-  
   echo ""
   echo "📋 Violações encontradas:"
   echo ""
+  convert_json_to_compact
   cat "$CODENARC_COMPACT"
   echo ""
 }
 
-convert_sarif_to_compact() {
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "⚠️  jq não encontrado"
-    return
-  fi
-
+convert_json_to_compact() {
   jq -r '
-    .runs[0]? as $run |
-    ($run.tool.driver.rules // []) as $rules |
-    ($run.results // [])[] |
-    .ruleId as $ruleId |
-    ($rules | map(select(.id == $ruleId)) | .[0].properties.priority // 2) as $priority |
-    (.locations[0].physicalLocation // {}) as $loc |
-    ($loc.artifactLocation.uri // "unknown") as $file |
-    ($loc.region.startLine // null) as $line |
-    (.message.text // "No message") as $msg |
-    if $line == null then
-      "\($file):\($ruleId) \($msg) => Priority \($priority)"
+    .packages[]? |
+    .path as $pkg_path |
+    .files[]? |
+    ($pkg_path // "") as $rawpath |
+    .name as $filename |
+    (if $rawpath == "" then $filename else ($rawpath | ltrimstr("/")) + "/" + $filename end) as $file |
+    ($file | ltrimstr("/")) as $cleanfile |
+    .violations[]? |
+    if .lineNumber then
+      "\($cleanfile):\(.lineNumber):\(.ruleName) \(.message // "") [P\(.priority)]"
     else
-      "\($file):\($line):\($ruleId) \($msg) => Priority \($priority)"
+      "\($cleanfile)::\(.ruleName) \(.message // "") [P\(.priority)]"
     end
-  ' "$CODENARC_SARIF" > "$CODENARC_COMPACT" 2>/dev/null || echo "" > "$CODENARC_COMPACT"
-}
-
-split_sarif_by_type() {
-  if ! command -v jq >/dev/null 2>&1; then
-    return
-  fi
-
-  # Line-based
-  jq '{
-    "$schema": ."$schema",
-    "version": .version,
-    "runs": [
-      .runs[0] | {
-        "tool": .tool,
-        "results": [.results[] | select(.locations[0].physicalLocation.region.startLine != null)]
-      }
-    ]
-  }' "$CODENARC_SARIF" > "$CODENARC_SARIF_LINE" 2>/dev/null
-
-  # File-based
-  jq '{
-    "$schema": ."$schema",
-    "version": .version,
-    "runs": [
-      .runs[0] | {
-        "tool": .tool,
-        "results": [.results[] | select(.locations[0].physicalLocation.region.startLine == null)]
-      }
-    ]
-  }' "$CODENARC_SARIF" > "$CODENARC_SARIF_FILE" 2>/dev/null
+  ' "$CODENARC_JSON" > "$CODENARC_COMPACT" 2>/dev/null || true
 }
 
 run_reviewdog() {
+  [ ! -s "$CODENARC_COMPACT" ] && return
+
   echo "📤 Enviando resultados para reviewdog..."
-  
-  if [ ! -s "$CODENARC_SARIF" ]; then
-    echo "⚠️  Nenhum resultado SARIF encontrado"
-    return
-  fi
 
   if [ "${INPUT_REPORTER}" = "local" ]; then
-    echo "🏠 Executando reviewdog em modo local..."
-    < "$CODENARC_SARIF" reviewdog \
-      -f=sarif \
+    < "$CODENARC_COMPACT" reviewdog \
+      -efm="%f:%l:%m" \
+      -efm="%f::%m" \
       -reporter="local" \
       -name="codenarc" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS} || true
-    return
-  fi
-
-  # line-based github-pr-review
-  if [ -s "$CODENARC_SARIF_LINE" ] && [ "$(jq '.runs[0].results | length' "$CODENARC_SARIF_LINE")" -gt 0 ]; then
-    echo "📍 Enviando violações line-based para github-pr-review..."
-    < "$CODENARC_SARIF_LINE" reviewdog \
-      -f=sarif \
+  else
+    grep -E ':[0-9]+:' "$CODENARC_COMPACT" | reviewdog \
+      -efm="%f:%l:%m" \
       -reporter="github-pr-review" \
       -name="codenarc" \
       -filter-mode="${INPUT_FILTER_MODE}" \
-      -fail-on-error="false" \
       -level="${INPUT_LEVEL}" \
       ${INPUT_REVIEWDOG_FLAGS} || true
-  fi
 
-  # file-based github-pr-check
-  if [ -s "$CODENARC_SARIF_FILE" ] && [ "$(jq '.runs[0].results | length' "$CODENARC_SARIF_FILE")" -gt 0 ]; then
-    echo "📄 Enviando violações file-based para github-pr-check..."
-    < "$CODENARC_SARIF_FILE" reviewdog \
-      -f=sarif \
+    grep -E '::' "$CODENARC_COMPACT" | reviewdog \
+      -efm="%f::%m" \
       -reporter="github-pr-check" \
       -name="codenarc" \
       -filter-mode="nofilter" \
-      -fail-on-error="false" \
       -level="warning" \
       ${INPUT_REVIEWDOG_FLAGS} || true
   fi
@@ -152,171 +94,108 @@ generate_git_diff() {
   fi
 }
 
-parse_diff_range() {
-  range="$1"
-  if echo "$range" | grep -q ","; then
-    echo "$(echo "$range" | cut -d',' -f1) $(echo "$range" | cut -d',' -f2)"
-  else
-    echo "$range 1"
-  fi
-}
+
 
 build_changed_lines_cache() {
-  true > "$CHANGED_LINES_CACHE"
-  true > "$CHANGED_FILES_CACHE"
-  
-  generate_git_diff > "$ALL_DIFF" 2>/dev/null || true
-  [ ! -s "$ALL_DIFF" ] && return 0
-  
-  current_file=""
-  while read -r line; do
-    case "$line" in
-      "diff --git"*)
-        current_file=$(echo "$line" | sed 's|^diff --git a/\(.*\) b/.*|\1|')
-        [ -n "$current_file" ] && echo "$current_file" >> "$CHANGED_FILES_CACHE"
-        ;;
-      "@@"*)
-        [ -z "$current_file" ] && continue
-        range=$(echo "$line" | sed 's/.*+\([0-9,]*\).*/\1/')
-        range_info=$(parse_diff_range "$range")
-        start=$(echo "$range_info" | cut -d' ' -f1)
-        count=$(echo "$range_info" | cut -d' ' -f2)
-        
-        case "$start" in ''|*[!0-9]*) continue ;; esac
-        case "$count" in ''|*[!0-9]*) continue ;; esac
-        
-        i="$start"
-        while [ "$i" -lt "$((start + count))" ]; do
-          echo "$current_file:$i" >> "$CHANGED_LINES_CACHE"
-          i=$((i + 1))
-        done
-        ;;
-    esac
-  done < "$ALL_DIFF"
+  generate_git_diff > "$ALL_DIFF" 2>/dev/null || return
+  [ ! -s "$ALL_DIFF" ] && return
+
+  awk '
+    /^diff --git/ { file = $3; sub(/^a\//, "", file); print file > "/tmp/changed_files.txt" }
+    /^@@/ {
+      match($0, /\+([0-9]+)(,([0-9]+))?/, arr)
+      start = arr[1]
+      count = arr[3] ? arr[3] : 1
+      for (i = start; i < start + count; i++)
+        print file ":" i > "/tmp/changed_lines.txt"
+    }
+  ' "$ALL_DIFF"
 }
 
-get_allowed_patterns() {
-  [ -n "$INPUT_SOURCE_FILES" ] && echo "$INPUT_SOURCE_FILES" | tr ',' '\n' | sed 's/\*\*/.*/g'
+file_matches_filter() {
+  [ -z "$INPUT_SOURCE_FILES" ] && return 0
+  echo "$INPUT_SOURCE_FILES" | tr ',' '\n' | sed 's/\*\*/.*/g' | grep -qE "$(echo "$1" | sed 's/\./\\./g')"
 }
 
-file_matches_patterns() {
-  file="$1"
-  patterns="$2"
-  [ -z "$patterns" ] && return 0
-  for pattern in $patterns; do
-    echo "$file" | grep -Eq "$pattern" && return 0
-  done
+is_changed() {
+  [ -f "$CHANGED_LINES_CACHE" ] && grep -q "^$1:$2$" "$CHANGED_LINES_CACHE" && return 0
+  [ -f "$CHANGED_FILES_CACHE" ] && grep -q "^$1$" "$CHANGED_FILES_CACHE" && return 0
   return 1
 }
 
-is_line_changed() {
-  grep -q "^$2:$1$" "$CHANGED_LINES_CACHE"
-}
-
-is_file_changed() {
-  grep -q "^$1$" "$CHANGED_FILES_CACHE"
-}
-
-extract_p1_violations_from_sarif() {
-  if ! command -v jq >/dev/null 2>&1; then
-    grep 'Priority 1' "$CODENARC_COMPACT" 2>/dev/null || echo ""
-    return
-  fi
-
+extract_p1_violations() {
   jq -r '
-    .runs[0]? as $run |
-    ($run.tool.driver.rules // []) as $rules |
-    ($run.results // [])[] |
-    .ruleId as $ruleId |
-    ($rules | map(select(.id == $ruleId)) | .[0].properties.priority // 2) as $priority |
-    select($priority == 1) |
-    (.locations[0].physicalLocation // {}) as $loc |
-    ($loc.artifactLocation.uri // "unknown") as $file |
-    ($loc.region.startLine // null) as $line |
-    (.message.text // "No message") as $msg |
-    if $line == null then
-      "\($file)::\($ruleId) \($msg)"
+    .packages[]? |
+    .path as $pkg_path |
+    .files[]? |
+    ($pkg_path // "") as $rawpath |
+    .name as $filename |
+    (if $rawpath == "" then $filename else ($rawpath | ltrimstr("/")) + "/" + $filename end) as $file |
+    ($file | ltrimstr("/")) as $cleanfile |
+    .violations[]? | select(.priority == 1) |
+    if .lineNumber then
+      "\($cleanfile):\(.lineNumber):\(.ruleName) \(.message // "")"
     else
-      "\($file):\($line):\($ruleId) \($msg)"
+      "\($cleanfile)::\(.ruleName) \(.message // "")"
     end
-  ' "$CODENARC_SARIF" 2>/dev/null || echo ""
+  ' "$CODENARC_JSON" 2>/dev/null
 }
 
 check_blocking_rules() {
   echo "🔎 Verificando violações bloqueantes (priority 1)..."
-  
-  [ ! -f "$CODENARC_SARIF" ] && echo "❌ Resultado não encontrado" && return 1
-  
-  p1_violations=$(extract_p1_violations_from_sarif)
-  
+
+  [ ! -f "$CODENARC_JSON" ] && echo "❌ Resultado não encontrado" && return 1
+
+  p1_violations=$(extract_p1_violations)
+
   if [ -z "$p1_violations" ]; then
     echo "✅ Nenhuma P1 detectada → merge permitido"
     return 0
   fi
-  
+
   p1_count=$(echo "$p1_violations" | wc -l | tr -d ' ')
   echo "📊 Total de P1 encontradas: $p1_count"
   echo ""
   echo "⛔ Violações P1:"
   echo "$p1_violations"
   echo ""
-  
+
   if [ "${INPUT_REPORTER}" = "local" ]; then
-    echo "🏠 Modo local - não é possível verificar linhas alteradas"
-    echo "⚠️  Todas as P1s serão consideradas bloqueantes"
-    echo ""
-    echo "⛔ Violação P1 encontrada → bloqueando execução"
+    echo "🏠 Modo local - todas as P1s são bloqueantes"
     echo "💡 Corrija as violações antes de prosseguir."
     exit 1
   fi
-  
+
   echo "⚠️  Verificando se P1s estão em linhas alteradas..."
   build_changed_lines_cache
-  
+
   if [ ! -s "$ALL_DIFF" ]; then
-    echo "⚠️  Não foi possível gerar diff - considerando todas as P1s como bloqueantes"
-    echo ""
-    echo "⛔ Violação P1 encontrada → bloqueando merge"
-    echo "💡 Corrija as violações ou use o bypass autorizado pelo coordenador."
+    echo "⚠️  Diff vazio - considerando todas as P1s como bloqueantes"
+    echo "💡 Corrija as violações ou use o bypass autorizado."
     exit 1
   fi
-  
-  allowed_patterns=$(get_allowed_patterns)
-  [ -n "$allowed_patterns" ] && echo "🧩 Analisando apenas arquivos filtrados"
-  
-  echo "0" > "$VIOLATIONS_FLAG"
-  
+
+  [ -n "$INPUT_SOURCE_FILES" ] && echo "🧩 Analisando apenas arquivos filtrados"
+
   echo "$p1_violations" | while IFS=: read -r file line rest; do
     [ -z "$file" ] && continue
-    file_matches_patterns "$file" "$allowed_patterns" || continue
-    
-    if [ "$line" = "" ] || [ -z "$line" ]; then
-      if is_file_changed "$file"; then
-        echo "⛔ Violação P1 file-based em arquivo alterado: $file"
-        echo "   $rest"
-        echo "1" > "$VIOLATIONS_FLAG"
-        break
-      fi
-    elif is_line_changed "$line" "$file"; then
-      echo "⛔ Violação P1 em linha alterada: $file:$line"
-      echo "   $rest"
-      echo "1" > "$VIOLATIONS_FLAG"
-      break
+    file_matches_filter "$file" || continue
+
+    if [ -z "$line" ]; then
+      is_changed "$file" "" && echo "⛔ $file (file-level): $rest" && exit 1
+    else
+      is_changed "$file" "$line" && echo "⛔ $file:$line: $rest" && exit 1
     fi
   done
-  
-  if [ "$(cat "$VIOLATIONS_FLAG")" -eq 1 ]; then
-    echo ""
-    echo "⛔ Violação P1 encontrada em linha alterada → bloqueando merge"
-    echo "💡 Corrija as violações ou use o bypass autorizado pelo coordenador."
-    exit 1
-  else
-    echo "✅ P1s existem mas fora das linhas alteradas → merge permitido"
-  fi
+
+  [ $? -eq 1 ] && echo "" && echo "💡 Corrija as violações ou use o bypass autorizado." && exit 1
+
+  echo "✅ P1s existem mas fora das linhas alteradas → merge permitido"
 }
 
 if [ -n "${GITHUB_WORKSPACE}" ]; then
-  git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+  cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit
+  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 set -e
 
-CODENARC_RESULT="result.txt"
+CODENARC_SARIF="result.sarif.json"
+CODENARC_SARIF_LINE="result_line.sarif.json"
+CODENARC_SARIF_FILE="result_file.sarif.json"
+CODENARC_COMPACT="result.txt"
 LINE_VIOLATIONS="line_violations.txt"
 FILE_VIOLATIONS="file_violations.txt"
 VIOLATIONS_FLAG="/tmp/found_violations.txt"
@@ -10,99 +13,132 @@ CHANGED_LINES_CACHE="/tmp/changed_lines.txt"
 CHANGED_FILES_CACHE="/tmp/changed_files.txt"
 
 cleanup_temp_files() {
-  rm -f "$CODENARC_RESULT" "$LINE_VIOLATIONS" "$FILE_VIOLATIONS" "$VIOLATIONS_FLAG" \
-        "$ALL_DIFF" "$CHANGED_LINES_CACHE" "$CHANGED_FILES_CACHE" \
+  rm -f "$CODENARC_SARIF" "$CODENARC_SARIF_LINE" "$CODENARC_SARIF_FILE" "$CODENARC_COMPACT" "$LINE_VIOLATIONS" "$FILE_VIOLATIONS" \
+        "$VIOLATIONS_FLAG" "$ALL_DIFF" "$CHANGED_LINES_CACHE" "$CHANGED_FILES_CACHE" \
         "${FILE_VIOLATIONS}.formatted" >/dev/null 2>&1
 }
 
 trap 'cleanup_temp_files' EXIT
 
 run_codenarc() {
-  report="${INPUT_REPORT:-compact:stdout}"
   includes_arg=""
-
   [ -n "$INPUT_SOURCE_FILES" ] && includes_arg="-includes=${INPUT_SOURCE_FILES}"
 
   echo "🔍 Executando CodeNarc..."
   java -jar /lib/codenarc-all.jar \
-    -report="$report" \
+    -report="sarif:${CODENARC_SARIF}" \
     -rulesetfiles="${INPUT_RULESETFILES}" \
     -basedir="." \
-    $includes_arg \
-    > "$CODENARC_RESULT"
+    $includes_arg
 
-  echo ""
-  echo ""
-  echo "📋 Saída do CodeNarc:"
-  echo ""
-  echo ""
-  cat "$CODENARC_RESULT"
-  echo ""
-  echo ""
-}
-
-run_reviewdog_with_config() {
-  input_file="$1"
-  efm="$2"
-  reporter="$3"
-  name="$4"
-  filter_mode="$5"
-  level="$6"
+  convert_sarif_to_compact
+  split_sarif_by_type
   
-  < "$input_file" reviewdog \
-    -efm="$efm" \
-    -reporter="$reporter" \
-    -name="$name" \
-    -filter-mode="$filter_mode" \
-    -fail-on-error="false" \
-    -level="$level" \
-    ${INPUT_REVIEWDOG_FLAGS} || true
+  echo ""
+  echo "📋 Violações encontradas:"
+  echo ""
+  cat "$CODENARC_COMPACT"
+  echo ""
 }
 
-separate_violations() {
-  grep -E ':[0-9]+:' "$CODENARC_RESULT" > "$LINE_VIOLATIONS" || true
-  grep -E ':null:|\|\|' "$CODENARC_RESULT" > "$FILE_VIOLATIONS" || true
+convert_sarif_to_compact() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "⚠️  jq não encontrado"
+    return
+  fi
+
+  jq -r '
+    .runs[0]? as $run |
+    ($run.tool.driver.rules // []) as $rules |
+    ($run.results // [])[] |
+    .ruleId as $ruleId |
+    ($rules | map(select(.id == $ruleId)) | .[0].properties.priority // 2) as $priority |
+    (.locations[0].physicalLocation // {}) as $loc |
+    ($loc.artifactLocation.uri // "unknown") as $file |
+    ($loc.region.startLine // null) as $line |
+    (.message.text // "No message") as $msg |
+    if $line == null then
+      "\($file):\($ruleId) \($msg) => Priority \($priority)"
+    else
+      "\($file):\($line):\($ruleId) \($msg) => Priority \($priority)"
+    end
+  ' "$CODENARC_SARIF" > "$CODENARC_COMPACT" 2>/dev/null || echo "" > "$CODENARC_COMPACT"
+}
+
+split_sarif_by_type() {
+  if ! command -v jq >/dev/null 2>&1; then
+    return
+  fi
+
+  # Line-based
+  jq '{
+    "$schema": ."$schema",
+    "version": .version,
+    "runs": [
+      .runs[0] | {
+        "tool": .tool,
+        "results": [.results[] | select(.locations[0].physicalLocation.region.startLine != null)]
+      }
+    ]
+  }' "$CODENARC_SARIF" > "$CODENARC_SARIF_LINE" 2>/dev/null
+
+  # File-based
+  jq '{
+    "$schema": ."$schema",
+    "version": .version,
+    "runs": [
+      .runs[0] | {
+        "tool": .tool,
+        "results": [.results[] | select(.locations[0].physicalLocation.region.startLine == null)]
+      }
+    ]
+  }' "$CODENARC_SARIF" > "$CODENARC_SARIF_FILE" 2>/dev/null
 }
 
 run_reviewdog() {
   echo "📤 Enviando resultados para reviewdog..."
   
-  separate_violations
-  
-  if [ -s "$LINE_VIOLATIONS" ]; then
-    echo "📤 Enviando violações line-based (${INPUT_REPORTER:-github-pr-check})..."
-    run_reviewdog_with_config "$LINE_VIOLATIONS" "%f:%l:%m" \
-      "${INPUT_REPORTER:-github-pr-check}" "codenarc" \
-      "${INPUT_FILTER_MODE}" "${INPUT_LEVEL}"
+  if [ ! -s "$CODENARC_SARIF" ]; then
+    echo "⚠️  Nenhum resultado SARIF encontrado"
+    return
   fi
-  
-  if [ -s "$FILE_VIOLATIONS" ]; then
-    true > "${FILE_VIOLATIONS}.formatted"
-    while read -r violation; do
-      if echo "$violation" | grep -q '||'; then
-        echo "$violation" | sed 's/||/::/'
-      else
-        echo "$violation" | sed 's/:null:/::/'
-      fi
-    done < "$FILE_VIOLATIONS" > "${FILE_VIOLATIONS}.formatted"
-    
-    if [ "${INPUT_REPORTER}" = "local" ]; then
-      echo "📤 Enviando violações file-based (local)..."
-      run_reviewdog_with_config "${FILE_VIOLATIONS}.formatted" "%f::%m" \
-        "local" "codenarc" "nofilter" "${INPUT_LEVEL}"
-    else
-      echo "📤 Enviando violações file-based (github-pr-check)..."
-      run_reviewdog_with_config "${FILE_VIOLATIONS}.formatted" "%f::%m" \
-        "github-pr-check" "codenarc" "nofilter" "warning"
-    fi
+
+  if [ "${INPUT_REPORTER}" = "local" ]; then
+    echo "🏠 Executando reviewdog em modo local..."
+    < "$CODENARC_SARIF" reviewdog \
+      -f=sarif \
+      -reporter="local" \
+      -name="codenarc" \
+      -filter-mode="${INPUT_FILTER_MODE}" \
+      -level="${INPUT_LEVEL}" \
+      ${INPUT_REVIEWDOG_FLAGS} || true
+    return
   fi
-  
-  # fallback se nao houver violacoes categorizadas
-  if [ ! -s "$LINE_VIOLATIONS" ] && [ ! -s "$FILE_VIOLATIONS" ]; then
-    echo "📝 Executando reviewdog padrão..."
-    run_reviewdog_with_config "$CODENARC_RESULT" "%f:%l:%m" \
-      "${INPUT_REPORTER:-github-pr-check}" "codenarc" \
-      "${INPUT_FILTER_MODE}" "${INPUT_LEVEL}"
+
+  # line-based github-pr-review
+  if [ -s "$CODENARC_SARIF_LINE" ] && [ "$(jq '.runs[0].results | length' "$CODENARC_SARIF_LINE")" -gt 0 ]; then
+    echo "📍 Enviando violações line-based para github-pr-review..."
+    < "$CODENARC_SARIF_LINE" reviewdog \
+      -f=sarif \
+      -reporter="github-pr-review" \
+      -name="codenarc" \
+      -filter-mode="${INPUT_FILTER_MODE}" \
+      -fail-on-error="false" \
+      -level="${INPUT_LEVEL}" \
+      ${INPUT_REVIEWDOG_FLAGS} || true
+  fi
+
+  # file-based github-pr-check
+  if [ -s "$CODENARC_SARIF_FILE" ] && [ "$(jq '.runs[0].results | length' "$CODENARC_SARIF_FILE")" -gt 0 ]; then
+    echo "📄 Enviando violações file-based para github-pr-check..."
+    < "$CODENARC_SARIF_FILE" reviewdog \
+      -f=sarif \
+      -reporter="github-pr-check" \
+      -name="codenarc" \
+      -filter-mode="nofilter" \
+      -fail-on-error="false" \
+      -level="warning" \
+      ${INPUT_REVIEWDOG_FLAGS} || true
   fi
 }
 
@@ -159,11 +195,6 @@ build_changed_lines_cache() {
   done < "$ALL_DIFF"
 }
 
-get_p1_count() {
-  p1_count=$(grep -Eo "p1=[0-9]+" "$CODENARC_RESULT" | cut -d'=' -f2 | head -1)
-  echo "${p1_count:-0}"
-}
-
 get_allowed_patterns() {
   [ -n "$INPUT_SOURCE_FILES" ] && echo "$INPUT_SOURCE_FILES" | tr ',' '\n' | sed 's/\*\*/.*/g'
 }
@@ -171,9 +202,7 @@ get_allowed_patterns() {
 file_matches_patterns() {
   file="$1"
   patterns="$2"
-  
   [ -z "$patterns" ] && return 0
-  
   for pattern in $patterns; do
     echo "$file" | grep -Eq "$pattern" && return 0
   done
@@ -188,46 +217,98 @@ is_file_changed() {
   grep -q "^$1$" "$CHANGED_FILES_CACHE"
 }
 
+extract_p1_violations_from_sarif() {
+  if ! command -v jq >/dev/null 2>&1; then
+    grep 'Priority 1' "$CODENARC_COMPACT" 2>/dev/null || echo ""
+    return
+  fi
+
+  jq -r '
+    .runs[0]? as $run |
+    ($run.tool.driver.rules // []) as $rules |
+    ($run.results // [])[] |
+    .ruleId as $ruleId |
+    ($rules | map(select(.id == $ruleId)) | .[0].properties.priority // 2) as $priority |
+    select($priority == 1) |
+    (.locations[0].physicalLocation // {}) as $loc |
+    ($loc.artifactLocation.uri // "unknown") as $file |
+    ($loc.region.startLine // null) as $line |
+    (.message.text // "No message") as $msg |
+    if $line == null then
+      "\($file)::\($ruleId) \($msg)"
+    else
+      "\($file):\($line):\($ruleId) \($msg)"
+    end
+  ' "$CODENARC_SARIF" 2>/dev/null || echo ""
+}
+
 check_blocking_rules() {
   echo "🔎 Verificando violações bloqueantes (priority 1)..."
   
-  [ ! -f "$CODENARC_RESULT" ] && echo "❌ Resultado não encontrado" && return 1
+  [ ! -f "$CODENARC_SARIF" ] && echo "❌ Resultado não encontrado" && return 1
   
-  p1_count=$(get_p1_count)
+  p1_violations=$(extract_p1_violations_from_sarif)
+  
+  if [ -z "$p1_violations" ]; then
+    echo "✅ Nenhuma P1 detectada → merge permitido"
+    return 0
+  fi
+  
+  p1_count=$(echo "$p1_violations" | wc -l | tr -d ' ')
   echo "📊 Total de P1 encontradas: $p1_count"
+  echo ""
+  echo "⛔ Violações P1:"
+  echo "$p1_violations"
+  echo ""
   
-  [ "$p1_count" -eq 0 ] && echo "✅ Nenhuma P1 detectada → merge permitido" && return 0
+  if [ "${INPUT_REPORTER}" = "local" ]; then
+    echo "🏠 Modo local - não é possível verificar linhas alteradas"
+    echo "⚠️  Todas as P1s serão consideradas bloqueantes"
+    echo ""
+    echo "⛔ Violação P1 encontrada → bloqueando execução"
+    echo "💡 Corrija as violações antes de prosseguir."
+    exit 1
+  fi
   
-  echo "⚠️  Verificando P1s em linhas alteradas..."
+  echo "⚠️  Verificando se P1s estão em linhas alteradas..."
   build_changed_lines_cache
   
+  if [ ! -s "$ALL_DIFF" ]; then
+    echo "⚠️  Não foi possível gerar diff - considerando todas as P1s como bloqueantes"
+    echo ""
+    echo "⛔ Violação P1 encontrada → bloqueando merge"
+    echo "💡 Corrija as violações ou use o bypass autorizado pelo coordenador."
+    exit 1
+  fi
+  
   allowed_patterns=$(get_allowed_patterns)
-  [ -n "$allowed_patterns" ] && echo "🧩 Analisando apenas arquivos filtrados por INPUT_SOURCE_FILES"
+  [ -n "$allowed_patterns" ] && echo "🧩 Analisando apenas arquivos filtrados"
   
   echo "0" > "$VIOLATIONS_FLAG"
   
-  grep -E ':[0-9]+:|:null:|\|\|' "$CODENARC_RESULT" | while IFS=: read -r file line rest; do
-    if echo "$file" | grep -q '||'; then
-      file=$(echo "$file" | cut -d'|' -f1)
-      line=""
-    fi
+  echo "$p1_violations" | while IFS=: read -r file line rest; do
     [ -z "$file" ] && continue
     file_matches_patterns "$file" "$allowed_patterns" || continue
     
-    if [ -z "$line" ] || [ "$line" = "null" ]; then
+    if [ "$line" = "" ] || [ -z "$line" ]; then
       if is_file_changed "$file"; then
-        echo "📍 Violação file-based em arquivo alterado: $file"
-        echo "1" > "$VIOLATIONS_FLAG" && break
+        echo "⛔ Violação P1 file-based em arquivo alterado: $file"
+        echo "   $rest"
+        echo "1" > "$VIOLATIONS_FLAG"
+        break
       fi
     elif is_line_changed "$line" "$file"; then
-      echo "📍 Violação em linha alterada: $file:$line"
-      echo "1" > "$VIOLATIONS_FLAG" && break
+      echo "⛔ Violação P1 em linha alterada: $file:$line"
+      echo "   $rest"
+      echo "1" > "$VIOLATIONS_FLAG"
+      break
     fi
   done
   
   if [ "$(cat "$VIOLATIONS_FLAG")" -eq 1 ]; then
-    echo "⛔ P1s existem E há violações em linhas alteradas"
-    echo "💡 Corrija as violacoes ou use o bypass autorizado pelo coordenador."
+    echo ""
+    echo "⛔ Violação P1 encontrada em linha alterada → bloqueando merge"
+    echo "💡 Corrija as violações ou use o bypass autorizado pelo coordenador."
     exit 1
   else
     echo "✅ P1s existem mas fora das linhas alteradas → merge permitido"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -203,7 +203,9 @@ check_blocking_rules() {
   cat "$CHANGED_FILES_CACHE" 2>/dev/null || echo "(cache vazio)"
   echo ""
 
-  echo "$p1_violations" | while IFS=: read -r file line rest; do
+  found_blocking=0
+
+  while IFS=: read -r file line rest; do
     [ -z "$file" ] && continue
     file_matches_filter "$file" || continue
 
@@ -213,20 +215,24 @@ check_blocking_rules() {
       if is_changed "$file" ""; then
         echo "⛔ $file (file-level): $rest"
         echo ""
-        echo "💡 Corrija as violações ou use o bypass autorizado."
-        exit 1
+        found_blocking=1
+        break
       fi
     else
       if is_changed "$file" "$line"; then
         echo "⛔ $file:$line: $rest"
         echo ""
-        echo "💡 Corrija as violações ou use o bypass autorizado."
-        exit 1
+        found_blocking=1
+        break
       fi
     fi
-  done
-  
-  if [ $? -eq 1 ]; then
+  done <<EOF
+$p1_violations
+EOF
+
+  if [ $found_blocking -eq 1 ]; then
+    echo ""
+    echo "💡 Corrija as violações ou use o bypass autorizado."
     exit 1
   fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -200,10 +200,15 @@ check_blocking_rules() {
     [ -z "$file" ] && continue
     file_matches_filter "$file" || continue
 
+    echo "🔍 Verificando: $file:$line"
+
     if [ -z "$line" ]; then
       is_changed "$file" "" && echo "⛔ $file (file-level): $rest" && exit 1
     else
-      is_changed "$file" "$line" && echo "⛔ $file:$line: $rest" && exit 1
+      if is_changed "$file" "$line"; then
+        echo "⛔ $file:$line: $rest"
+        exit 1
+      fi
     fi
   done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -188,6 +188,13 @@ check_blocking_rules() {
   fi
 
   [ -n "$INPUT_SOURCE_FILES" ] && echo "🧩 Analisando apenas arquivos filtrados"
+  
+  echo "📝 Debug - Linhas alteradas:"
+  cat "$CHANGED_LINES_CACHE" 2>/dev/null || echo "(cache vazio)"
+  echo ""
+  echo "📝 Debug - Arquivos alterados:"
+  cat "$CHANGED_FILES_CACHE" 2>/dev/null || echo "(cache vazio)"
+  echo ""
 
   echo "$p1_violations" | while IFS=: read -r file line rest; do
     [ -z "$file" ] && continue

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,12 +25,9 @@ run_codenarc() {
     -basedir="." \
     $includes_arg >/dev/null 2>&1
   
-  echo ""
   echo "📋 Processando violações encontradas:"
-  echo ""
   convert_json_to_compact
   cat "$CODENARC_COMPACT"
-  echo ""
 }
 
 convert_json_to_compact() {
@@ -53,7 +50,6 @@ convert_json_to_compact() {
 
 run_reviewdog() {
   [ ! -s "$CODENARC_COMPACT" ] && return
-
   echo "📤 Enviando resultados para reviewdog..."
   
   if [ "${INPUT_REPORTER}" = "local" ]; then
@@ -64,7 +60,7 @@ run_reviewdog() {
       -name="codenarc" \
       -filter-mode="${INPUT_FILTER_MODE}" \
       -level="${INPUT_LEVEL}" \
-      ${INPUT_REVIEWDOG_FLAGS} || true
+      ${INPUT_REVIEWDOG_FLAGS} >/dev/null || true
   else
     line_violations=$(grep -E ':[0-9]+:' "$CODENARC_COMPACT" || true)
     if [ -n "$line_violations" ]; then
@@ -74,9 +70,8 @@ run_reviewdog() {
         -name="codenarc" \
         -filter-mode="${INPUT_FILTER_MODE}" \
         -level="${INPUT_LEVEL}" \
-        ${INPUT_REVIEWDOG_FLAGS} || true
+        ${INPUT_REVIEWDOG_FLAGS} >/dev/null || true
     fi
-
     file_violations=$(grep -E '::' "$CODENARC_COMPACT" || true)
     if [ -n "$file_violations" ]; then
       echo "$file_violations" | reviewdog \
@@ -85,7 +80,7 @@ run_reviewdog() {
         -name="codenarc" \
         -filter-mode="nofilter" \
         -level="warning" \
-        ${INPUT_REVIEWDOG_FLAGS} || true
+        ${INPUT_REVIEWDOG_FLAGS} >/dev/null || true
     fi
   fi
 }
@@ -170,7 +165,6 @@ check_blocking_rules() {
 
   p1_count=$(echo "$p1_violations" | wc -l | tr -d ' ')
   echo "📊 Total de P1 encontradas: $p1_count"
-  echo ""
   echo "⛔ Violações P1:"
   echo "$p1_violations"
   echo ""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,8 +99,8 @@ generate_git_diff() {
 }
 
 build_changed_lines_cache() {
-  > "$CHANGED_FILES_CACHE"
-  > "$CHANGED_LINES_CACHE"
+  true > "$CHANGED_FILES_CACHE"
+  true > "$CHANGED_LINES_CACHE"
 
   generate_git_diff > "$ALL_DIFF" 2>/dev/null || return
   [ ! -s "$ALL_DIFF" ] && return
@@ -126,8 +126,8 @@ build_changed_lines_cache() {
 }
 
 is_changed() {
-  local file="$1"
-  local line="$2"
+  file="$1"
+  line="$2"
   
   if [ -z "$line" ]; then
     [ -f "$CHANGED_FILES_CACHE" ] && grep -qF "$file" "$CHANGED_FILES_CACHE" && return 0

--- a/testdata/aBCd32/test.groovy
+++ b/testdata/aBCd32/test.groovy
@@ -1,0 +1,13 @@
+package aBCd32
+
+class Test {
+
+    boolean before() {
+        return true 
+    }
+
+    boolean after() { true }
+
+    void after() {
+    }
+}

--- a/testdata/basic.xml
+++ b/testdata/basic.xml
@@ -1,52 +1,217 @@
 <ruleset xmlns="http://codenarc.org/ruleset/1.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
-        xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
 
     <description/>
 
-    <rule class='org.codenarc.rule.basic.AssertWithinFinallyBlockRule'/>
-    <rule class='org.codenarc.rule.basic.AssignmentInConditionalRule'/>
-    <rule class='org.codenarc.rule.basic.BigDecimalInstantiationRule'/>
-    <rule class='org.codenarc.rule.basic.BitwiseOperatorInConditionalRule'/>
-    <rule class='org.codenarc.rule.basic.BooleanGetBooleanRule'/>
-    <rule class='org.codenarc.rule.basic.BrokenNullCheckRule'/>
-    <rule class='org.codenarc.rule.basic.BrokenOddnessCheckRule'/>
-    <rule class='org.codenarc.rule.basic.ClassForNameRule'/>
-    <rule class='org.codenarc.rule.basic.ComparisonOfTwoConstantsRule'/>
-    <rule class='org.codenarc.rule.basic.ComparisonWithSelfRule'/>
-    <rule class='org.codenarc.rule.basic.ConstantAssertExpressionRule'/>
-    <rule class='org.codenarc.rule.basic.ConstantTernaryExpressionRule'/>
-    <rule class='org.codenarc.rule.basic.ConstantIfExpressionRule'/>
-    <rule class='org.codenarc.rule.basic.DeadCodeRule'/>
-    <rule class='org.codenarc.rule.basic.DoubleNegativeRule'/>
-    <rule class='org.codenarc.rule.basic.DuplicateCaseStatementRule'/>
-    <rule class='org.codenarc.rule.basic.DuplicateMapKeyRule'/>
-    <rule class='org.codenarc.rule.basic.DuplicateSetValueRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyCatchBlockRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyClassRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyElseBlockRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyFinallyBlockRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyForStatementRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyIfStatementRule'/>
-    <rule class='org.codenarc.rule.basic.EmptySwitchStatementRule'/>
-    <rule class='org.codenarc.rule.basic.EmptySynchronizedStatementRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyStaticInitializerRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyTryBlockRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyWhileStatementRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyInstanceInitializerRule'/>
-    <rule class='org.codenarc.rule.basic.EmptyMethodRule'/>
-    <rule class='org.codenarc.rule.basic.EqualsAndHashCodeRule'/>
-    <rule class='org.codenarc.rule.basic.EqualsOverloadedRule'/>
-    <rule class='org.codenarc.rule.basic.ExplicitGarbageCollectionRule'/>
-    <rule class='org.codenarc.rule.basic.ForLoopShouldBeWhileLoopRule'/>
-    <rule class='org.codenarc.rule.basic.HardCodedWindowsFileSeparatorRule'/>
-    <rule class='org.codenarc.rule.basic.HardCodedWindowsRootDirectoryRule'/>
-    <rule class='org.codenarc.rule.basic.IntegerGetIntegerRule'/>
-    <rule class='org.codenarc.rule.basic.MultipleUnaryOperatorsRule'/>
-    <rule class='org.codenarc.rule.basic.RandomDoubleCoercedToZeroRule'/>
-    <rule class='org.codenarc.rule.basic.RemoveAllOnSelfRule'/>
-    <rule class='org.codenarc.rule.basic.ReturnFromFinallyBlockRule'/>
-    <rule class='org.codenarc.rule.basic.ThrowExceptionFromFinallyBlockRule'/>
-    <rule class='org.codenarc.rule.basic.ParameterAssignmentInFilterClosureRule'/>
+    <rule class='org.codenarc.rule.basic.AssertWithinFinallyBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Evite usar assert dentro de blocos finally, pois pode mascarar exceções originais"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.AssignmentInConditionalRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Operador de atribuição (=) usado em condicional. Provavelmente deveria ser comparação (==)"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.BigDecimalInstantiationRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Use BigDecimal.valueOf() ao invés de new BigDecimal() com double/float para evitar problemas de precisão"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.BitwiseOperatorInConditionalRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Operador bitwise em expressão condicional. Extraia para uma variável temporária para melhor legibilidade"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.BooleanGetBooleanRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Boolean.getBoolean() lê propriedades do sistema, não converte String. Use Boolean.valueOf() para conversão"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.BrokenNullCheckRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Verificação de null incorreta. Use &amp;&amp; ao invés de || quando verificar null antes de usar o objeto"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.BrokenOddnessCheckRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Verificação de número ímpar incorreta. Use x % 2 != 0 ou x &amp; 1 == 1 para funcionar com negativos"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ClassForNameRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Evite Class.forName() pois pode causar vazamentos de memória mantendo classes carregadas por muito tempo"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ComparisonOfTwoConstantsRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Comparação entre duas constantes. O resultado é sempre o mesmo, remova ou corrija a lógica"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ComparisonWithSelfRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Comparação de variável consigo mesma. Remova ou corrija a lógica"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ConstantAssertExpressionRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Assert com valor constante. Remova ou use uma expressão dinâmica"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ConstantTernaryExpressionRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Expressão ternária com condição constante. Simplifique para o valor direto"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ConstantIfExpressionRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Condição if com valor constante. Remova o if ou use uma expressão dinâmica"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.DeadCodeRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Código morto detectado após return ou exception. Remova o código inalcançável"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.DoubleNegativeRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Dupla negação desnecessária. Simplifique !!x para x"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.DuplicateCaseStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Case duplicado no switch. Remova ou corrija a duplicação"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.DuplicateMapKeyRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Chave duplicada no Map. A entrada será sobrescrita"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.DuplicateSetValueRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Valor duplicado no Set. Sets não podem conter elementos iguais"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyCatchBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Bloco catch vazio. Adicione tratamento adequado ou pelo menos um comentário explicativo"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyClassRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Classe vazia sem métodos, campos ou propriedades. Adicione implementação ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyElseBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Bloco else vazio. Remova ou adicione implementação"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyFinallyBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Bloco finally vazio. Remova ou adicione código de limpeza necessário"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyForStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Loop for vazio. Adicione implementação ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyIfStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Bloco if vazio. Adicione implementação ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptySwitchStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Switch vazio. Adicione cases ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptySynchronizedStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Bloco synchronized vazio. Adicione implementação ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyStaticInitializerRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Inicializador estático vazio. Remova com segurança"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyTryBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Bloco try vazio. Adicione código que pode lançar exceção ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyWhileStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Loop while vazio. Adicione implementação ou remova"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyInstanceInitializerRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Inicializador de instância vazio. Remova com segurança"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EmptyMethodRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Método vazio encontrado. Adicione implementação ou marque com @Override se estiver sobrescrevendo"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EqualsAndHashCodeRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Classe define equals() mas não hashCode(). Implemente ambos para manter o contrato"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.EqualsOverloadedRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Método equals sobrecarregado ao invés de sobrescrito. Use equals(Object obj)"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ExplicitGarbageCollectionRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Chamada explícita ao garbage collector. Deixe a JVM gerenciar automaticamente"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ForLoopShouldBeWhileLoopRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Loop for sem inicialização e atualização pode ser simplificado para while"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.HardCodedWindowsFileSeparatorRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Separador de arquivo Windows hardcoded. Use File.separator para portabilidade"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.HardCodedWindowsRootDirectoryRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Diretório raiz Windows hardcoded. Use File.listRoots() para portabilidade"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.IntegerGetIntegerRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Integer.getInteger() lê propriedades do sistema, não converte String. Use Integer.valueOf() para conversão"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.MultipleUnaryOperatorsRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Múltiplos operadores unários consecutivos são confusos. Simplifique a expressão"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.RandomDoubleCoercedToZeroRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Math.random() convertido para int sempre resulta em 0. Multiplique antes de converter"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.RemoveAllOnSelfRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Chamada removeAll() com o próprio objeto como parâmetro. Provavelmente um erro"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ReturnFromFinallyBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Return dentro de bloco finally pode mascarar exceções. Evite retornar de finally"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ThrowExceptionFromFinallyBlockRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Lançar exceção de bloco finally pode mascarar exceções originais"/>
+    </rule>
+    <rule class='org.codenarc.rule.basic.ParameterAssignmentInFilterClosureRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Atribuição de parâmetro dentro de closure de filtro. Evite modificar parâmetros diretamente"/>
+    </rule>
+    <rule class='org.codenarc.rule.convention.ImplicitReturnStatementRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Método sem return explícito. Adicione return para clareza"/>
+    </rule>
+    <rule class='org.codenarc.rule.groovyism.ExplicitArrayListInstantiationRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Use [] ao invés de new ArrayList() para criar listas vazias em Groovy"/>
+    </rule>
+    <rule class='org.codenarc.rule.groovyism.GStringExpressionWithinStringRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Expressão GString (${..}) encontrada em string com aspas simples. Use aspas duplas para habilitar interpolação"/>
+    </rule>
+    <rule class='org.codenarc.rule.logging.PrintlnRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Uso de println. Use um sistema de log adequado"/>
+    </rule>
+    <rule class='org.codenarc.rule.naming.PackageNameRule'>
+        <property name="priority" value="2"/>
+        <property name="violationMessage" value="Nome do package deve seguir convenção: apenas letras minúsculas e números, separados por pontos"/>
+    </rule>
+    <rule class='org.codenarc.rule.generic.IllegalRegexRule'>
+        <property name='name' value='ForceHttps'/>
+        <property name='regex' value='http://'/>
+        <property name="priority" value="1"/>
+        <property name='violationMessage' value='Para maior segurança na chamada utilize HTTPS'/>
+    </rule>
+    <rule class='org.codenarc.rule.generic.IllegalRegexRule'>
+        <property name='name' value='VerifyUriComponentsBuilderVulnerability'/>
+        <property name='applyToFileNames' value='*.groovy'/>
+        <property name='regex' value='import.*org\.springframework\.web\.util\.UriComponentsBuilder'/>
+        <property name="priority" value="1"/>
+        <property name='violationMessage' value='Verifique se a utilização do objeto `UriComponentsBuilder` afeta o Asaas com relação à vulnerabilidade [CVE-2024-22243](https://spring.io/security/cve-2024-22243)'/>
+    </rule>
 </ruleset>

--- a/testdata/test.groovy
+++ b/testdata/test.groovy
@@ -6,7 +6,7 @@ class TestCase2 {
         println "existing"
     }
     
-    // ADICIONAR ESTAS LINHAS - P1 dentro do diff
+    // P1
     String insecureUrl = "http://api.example.com"
     
     void callApi() {

--- a/testdata/test.groovy
+++ b/testdata/test.groovy
@@ -1,41 +1,15 @@
-package testdata
+package com.test
 
-import org.springframework.web.util.UriComponentsBuilder
-
-class Test {
-
-    // P1 - ForceHttps
-    String url = "http://example.com"
-
-    // P1 - VerifyUriComponentsBuilderVulnerability  
-    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl("test")
-
-    boolean before() {
-        return true // P2 - ImplicitReturnStatement
+class TestCase2 {
+    
+    void existingMethod() {
+        println "existing"
     }
-
-    boolean after() { true } // P2 - ImplicitReturnStatement
-
-    void after() { // P2 - EmptyMethod
-    }
-
-    // P2 - Multiple violations
-    def x = new ArrayList() // P2 - ExplicitArrayListInstantiation
-    String msg = 'Hello ${name}' // P2 - GStringExpressionWithinString
-
-    void testMethod() {
-        if (true) { // P2 - ConstantIfExpression
-            println "test" // P2 - PrintlnRule
-        }
-
-        // P2 - AssignmentInConditional
-        if (x = 5) {
-            return
-        }
-
-        // P2 - ComparisonWithSelf
-        if (x == x) {
-            return
-        }
+    
+    // ADICIONAR ESTAS LINHAS - P1 dentro do diff
+    String insecureUrl = "http://api.example.com"
+    
+    void callApi() {
+        // usar insecureUrl
     }
 }

--- a/testdata/test.groovy
+++ b/testdata/test.groovy
@@ -1,13 +1,41 @@
-package test
+package testdata
+
+import org.springframework.web.util.UriComponentsBuilder
 
 class Test {
 
+    // P1 - ForceHttps
+    String url = "http://example.com"
+
+    // P1 - VerifyUriComponentsBuilderVulnerability  
+    UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl("test")
+
     boolean before() {
-        return true 
+        return true // P2 - ImplicitReturnStatement
     }
 
-    boolean after() { true }
+    boolean after() { true } // P2 - ImplicitReturnStatement
 
-    void after() {
+    void after() { // P2 - EmptyMethod
+    }
+
+    // P2 - Multiple violations
+    def x = new ArrayList() // P2 - ExplicitArrayListInstantiation
+    String msg = 'Hello ${name}' // P2 - GStringExpressionWithinString
+
+    void testMethod() {
+        if (true) { // P2 - ConstantIfExpression
+            println "test" // P2 - PrintlnRule
+        }
+
+        // P2 - AssignmentInConditional
+        if (x = 5) {
+            return
+        }
+
+        // P2 - ComparisonWithSelf
+        if (x == x) {
+            return
+        }
     }
 }


### PR DESCRIPTION
### **Impacto**

Esta alteração corrige falsos positivos no bloqueio de merge do `codenarc-action` e aprimora a exibição da prioridade das violações do CodeNarc nos logs.

**Problema anterior:**

*   O script bloqueava o merge quando detectava violações de Prioridade 1 (P1) em um arquivo *e* qualquer violação em linhas alteradas, mesmo que a P1 não estivesse na linha alterada, resultando em **falsos positivos**.
*   Não havia uma forma precisa de identificar se uma violação específica em uma linha alterada era de fato uma P1, pois o formato `compact` do CodeNarc não fornecia a prioridade individualmente.

**Solução implementada:**

*   **Extração precisa de Prioridade:** O CodeNarc agora gera seu relatório em formato **JSON**, que inclui explicitamente a prioridade (`priority`) de cada violação.
*   **Parseamento e Filtragem:** Um script `jq` foi integrado para extrair seletivamente as violações de **Prioridade 1 (P1)** do relatório JSON e formatá-las em um output compacto.
*   **Verificação no Diff Aprimorada:** Apenas as violações P1 que estão **explicitamente localizadas em linhas alteradas** no diff de código bloqueiam o merge, eliminando os falsos positivos.
*   **Logs Claros:** As violações exibidas nos logs agora incluem as tags `[P1]`, `[P2]`, `[P3]`, facilitando a identificação e a depuração.
*   **Integração com Reviewdog:** O `reviewdog` processa o output formatado (agora contendo a prioridade) utilizando `errorformat` (`-efm`). Violações baseadas em linha são reportadas como `github-pr-review` e violações baseadas em arquivo como `github-pr-check`.

**Observação sobre SARIF:**
A utilização do formato SARIF do CodeNarc, embora inicialmente considerada e um padrão mais robusto, foi adiada. O suporte a SARIF no CodeNarc é uma funcionalidade muito recente (implementada na branch `master` e sem uma versão estável/tag liberada no momento). Para garantir a estabilidade e evitar dependências em funcionalidades instáveis, optou-se por uma abordagem alternativa robusta que atinge os mesmos objetivos de precisão e exibição de prioridade, utilizando as versões estáveis existentes do CodeNarc e Reviewdog.

### **Link da tarefa no JIRA**

https://asaas.atlassian.net/browse/DVT-1005

### **Mudanças técnicas:**

*   **CodeNarc:** Mantido na versão estável `3.6.0-groovy3.0.23`. A configuração de output foi alterada para `JSON` para incluir a `priority` de cada violação.
*   **Reviewdog:** Mantido na versão `v0.13.0`. A integração é feita via `errorformat` (`-efm`), sem a necessidade de suporte direto a SARIF.
*   **Dockerfile:** Adicionado `jq` para o parseamento do JSON do CodeNarc. O script `entrypoint.sh` teve `chmod +x` adicionado.
*   **Script `entrypoint.sh`:**
    *   Atualizado para gerar o relatório do CodeNarc em JSON.
    *   Implementado um novo método `convert_json_to_compact` que utiliza `jq` para formatar o JSON em um formato legível, incluindo a prioridade (`[P1]`).
    *   A lógica em `check_blocking_rules` foi revisada para extrair apenas P1s do JSON, verificar sua presença em linhas alteradas e bloquear o merge de forma precisa.
    *   A forma como o `reviewdog` é alimentado foi adaptada para o formato compacto (`errorformat`).

### **Cenários testados**

✅ **Bloqueio correto (sem falsos positivos)**

<details>
<summary>Cenário 1: P1 fora do diff + P2 dentro → NÃO deve bloquear ✅</summary>

https://github.com/asaasdev/test-workflows-run/pull/907

https://github.com/asaasdev/test-workflows-run/actions/runs/21264924084/job/61290272849?pr=907

<img width="978" height="845" alt="image" src="https://github.com/user-attachments/assets/0c4a7846-a60d-475e-ae04-55f90ee93cc9" />

<img width="1086" height="758" alt="image" src="https://github.com/user-attachments/assets/fa3ea872-c5c5-4e1c-b724-92919d6d54c3" />

<img width="1805" height="509" alt="image" src="https://github.com/user-attachments/assets/012d94d0-98c7-435e-8c0f-70e6a1bd7771" />

</details>

<details>
<summary>Cenário 2: P1 dentro do diff → DEVE bloquear ❌</b></summary>

https://github.com/asaasdev/test-workflows-run/pull/908

https://github.com/asaasdev/test-workflows-run/actions/runs/21265632030/job/61290264034?pr=908

<img width="967" height="896" alt="image" src="https://github.com/user-attachments/assets/81ed098e-b8d3-4931-99a8-9d5c50010559" />

<img width="1096" height="574" alt="image" src="https://github.com/user-attachments/assets/d6282cc4-207c-4359-bb34-fcf35d52290e" />

<img width="1216" height="484" alt="image" src="https://github.com/user-attachments/assets/5196d23c-530a-4555-b710-90fb0c6e9a1d" />

</details>

<details>
<summary>Cenário 3: Apenas P2 → NÃO deve bloquear ✅</summary>

https://github.com/asaasdev/test-workflows-run/pull/914

https://github.com/asaasdev/test-workflows-run/actions/runs/21293863565/job/61294428119?pr=914

<img width="1060" height="897" alt="image" src="https://github.com/user-attachments/assets/d9ce5ac2-fbec-4215-9811-ea3486ff3778" />

<img width="1022" height="785" alt="image" src="https://github.com/user-attachments/assets/ede450c6-b31e-4157-86a9-aba0d29a0d56" />

<img width="1393" height="238" alt="image" src="https://github.com/user-attachments/assets/b299c092-09a8-4a7e-994b-116a231177f4" />

</details>


<details>
<summary>Cenário 4: Violação file-based (PackageName) → Detectar corretamente</summary>

https://github.com/asaasdev/test-workflows-run/pull/915

https://github.com/asaasdev/test-workflows-run/actions/runs/21293864534/job/61294431297?pr=915

https://github.com/asaasdev/test-workflows-run/runs/61294483610

<img width="2043" height="640" alt="image" src="https://github.com/user-attachments/assets/7e7f21b6-e7de-4ebd-b96a-dedf1800a9bf" />

<img width="1056" height="754" alt="image" src="https://github.com/user-attachments/assets/d7ebc255-fb68-43bb-b26e-b413db839868" />

<img width="1321" height="191" alt="image" src="https://github.com/user-attachments/assets/09954a1b-719f-41b0-83de-b21592cf808d" />

</details>


<details>
<summary>Cenário 5: Múltiplas P1 - algumas dentro, outras fora do diff → DEVE bloquear ❌</summary>

https://github.com/asaasdev/test-workflows-run/pull/916

https://github.com/asaasdev/test-workflows-run/actions/runs/21293865641/job/61294435683?pr=916

<img width="987" height="890" alt="image" src="https://github.com/user-attachments/assets/fe4de23a-abed-4375-9470-c891e6f13e9e" />

<img width="1003" height="716" alt="image" src="https://github.com/user-attachments/assets/8f4e1ed1-1939-4e62-b6ec-ec31a8d1531e" />

<img width="1875" height="387" alt="image" src="https://github.com/user-attachments/assets/b0177b02-cc4e-4a2f-a282-ef44b68cd622" />

</details>


<details>
<summary>Cenário 6: Modo local (sem git diff)</summary>

<img width="1339" height="499" alt="image" src="https://github.com/user-attachments/assets/9d7090b5-9023-4088-8286-7a361350f54f" />

</details>

✅ **Logs exibem priority**
*   Cada violação mostra `[P1]`, `[P2]`, `[P3]`
*   Lista de P1s exibida quando existem
*   Formato: `arquivo:linha:Regra Mensagem [PX]`

✅ **Reviewdog funciona**
*   Comentários aparecem no PR (violações line-based → `github-pr-review`)
*   Checks de arquivo aparecem no PR (violações file-based → `github-pr-check`)
*   Modo local funciona com `-reporter=local`

✅ **Casos especiais**
*   Violações a nível de arquivo (sem número de linha) são detectadas corretamente e bloqueiam se forem P1 em um arquivo alterado.
*   No modo local, todas as P1s são bloqueantes (não há verificação de diff).
*   Se o diff estiver vazio, todas as P1s são consideradas bloqueantes (medida de segurança).