### PR TITLE
fix: configura autenticacao git no codenarc action para evitar erro 128

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -228,7 +228,7 @@ if [ -n "${GITHUB_WORKSPACE}" ]; then
 fi
 
 if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
-  git config --global url."https://x-access-token:${INPUT_GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+  git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=${INPUT_GITHUB_TOKEN}"; }; f'
 fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,11 +90,15 @@ run_reviewdog() {
 
 generate_git_diff() {
   if [ -n "$GITHUB_BASE_SHA" ] && [ -n "$GITHUB_HEAD_SHA" ]; then
-    git fetch origin "$GITHUB_BASE_SHA" --depth=1 >/dev/null 2>&1 || true
-    git fetch origin "$GITHUB_HEAD_SHA" --depth=1 >/dev/null 2>&1 || true
-    git diff -U0 "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.groovy'
+    if git cat-file -e "$GITHUB_BASE_SHA" 2>/dev/null && git cat-file -e "$GITHUB_HEAD_SHA" 2>/dev/null; then
+      git diff -U0 "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.groovy' 2>&1
+    else
+      git fetch origin "$GITHUB_BASE_SHA" --depth=1 2>&1 || true
+      git fetch origin "$GITHUB_HEAD_SHA" --depth=1 2>&1 || true
+      git diff -U0 "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.groovy' 2>&1
+    fi
   else
-    git diff -U0 HEAD~1 -- '*.groovy'
+    git diff -U0 HEAD~1 -- '*.groovy' 2>&1
   fi
 }
 
@@ -102,8 +106,8 @@ build_changed_lines_cache() {
   true > "$CHANGED_FILES_CACHE"
   true > "$CHANGED_LINES_CACHE"
 
-  generate_git_diff > "$ALL_DIFF" 2>/dev/null || return
-  [ ! -s "$ALL_DIFF" ] && return
+  generate_git_diff > "$ALL_DIFF" 2>&1
+  [ ! -s "$ALL_DIFF" ] && return 1
 
   awk '
     BEGIN { file = ""; line_num = 0 }
@@ -185,12 +189,9 @@ check_blocking_rules() {
 
   echo ""
   echo "⚠️  Analisando se as P1s estão em linhas alteradas..."
-  build_changed_lines_cache
-
-  if [ ! -s "$ALL_DIFF" ]; then
-    echo ""
-    echo "⚠️  Diff vazio: Sem informações de linhas alteradas. Todas as P1s são consideradas bloqueantes."
-    echo "💡 Corrija as violações ou use um bypass autorizado."
+  
+  if ! build_changed_lines_cache || [ ! -s "$ALL_DIFF" ]; then
+    echo "❌ Não foi possível gerar diff. Todas as P1s serão consideradas bloqueantes."
     exit 1
   fi
   

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,15 +90,11 @@ run_reviewdog() {
 
 generate_git_diff() {
   if [ -n "$GITHUB_BASE_SHA" ] && [ -n "$GITHUB_HEAD_SHA" ]; then
-    if git cat-file -e "$GITHUB_BASE_SHA" 2>/dev/null && git cat-file -e "$GITHUB_HEAD_SHA" 2>/dev/null; then
-      git diff -U0 "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.groovy' 2>&1
-    else
-      git fetch origin "$GITHUB_BASE_SHA" --depth=1 2>&1 || true
-      git fetch origin "$GITHUB_HEAD_SHA" --depth=1 2>&1 || true
-      git diff -U0 "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.groovy' 2>&1
-    fi
+    git fetch origin "$GITHUB_BASE_SHA" --depth=1 >/dev/null 2>&1 || true
+    git fetch origin "$GITHUB_HEAD_SHA" --depth=1 >/dev/null 2>&1 || true
+    git diff -U0 "$GITHUB_BASE_SHA" "$GITHUB_HEAD_SHA" -- '*.groovy'
   else
-    git diff -U0 HEAD~1 -- '*.groovy' 2>&1
+    git diff -U0 HEAD~1 -- '*.groovy'
   fi
 }
 
@@ -106,8 +102,8 @@ build_changed_lines_cache() {
   true > "$CHANGED_FILES_CACHE"
   true > "$CHANGED_LINES_CACHE"
 
-  generate_git_diff > "$ALL_DIFF" 2>&1
-  [ ! -s "$ALL_DIFF" ] && return 1
+  generate_git_diff > "$ALL_DIFF" 2>/dev/null || return
+  [ ! -s "$ALL_DIFF" ] && return
 
   awk '
     BEGIN { file = ""; line_num = 0 }
@@ -189,9 +185,12 @@ check_blocking_rules() {
 
   echo ""
   echo "⚠️  Analisando se as P1s estão em linhas alteradas..."
-  
-  if ! build_changed_lines_cache || [ ! -s "$ALL_DIFF" ]; then
-    echo "❌ Não foi possível gerar diff. Todas as P1s serão consideradas bloqueantes."
+  build_changed_lines_cache
+
+  if [ ! -s "$ALL_DIFF" ]; then
+    echo ""
+    echo "⚠️  Diff vazio: Sem informações de linhas alteradas. Todas as P1s são consideradas bloqueantes."
+    echo "💡 Corrija as violações ou use um bypass autorizado."
     exit 1
   fi
   
@@ -226,6 +225,10 @@ EOF
 if [ -n "${GITHUB_WORKSPACE}" ]; then
   cd "${GITHUB_WORKSPACE}/${INPUT_WORKDIR}" || exit 1
   git config --global --add safe.directory "$GITHUB_WORKSPACE"
+fi
+
+if [ -n "${INPUT_GITHUB_TOKEN}" ]; then
+  git config --global url."https://x-access-token:${INPUT_GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
 fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"


### PR DESCRIPTION
### Impacto

Configurada autenticação git no CodeNarc para resolver erro 128 que ocorria ao tentar fazer `git fetch` sem credenciais. O `github_token` já era passado para o container, mas não estava configurado para operações git.

**Mudança:**

- Adicionada configuração de autenticação git usando o token do GitHub já disponível
- Git agora usa automaticamente o token para operações HTTPS

**Causa raiz:** O token do GitHub era usado apenas para a API do reviewdog, mas não estava configurado para autenticação de operações git (fetch/pull). Com `fetch-depth: 2` no checkout, commits mais antigos não estavam disponíveis localmente, causando falha ao tentar fetch.

### Cenários testados

- Antes da correção (com erro)

```
⚠️  Analisando se as P1s estão em linhas alteradas...
fatal: could not read Username for 'https://github.com': No such device or address
Error: Process completed with exit code 128.
```

https://github.com/asaasdev/asaas/pull/55852

https://github.com/asaasdev/asaas/actions/runs/21633090397/job/62354435129

<img width="703" height="448" alt="image" src="https://github.com/user-attachments/assets/e8b352ef-7cfb-46ef-b291-d553b5a94d33" />


- Depois da correção (funcionando)

```
⚠️  Analisando se as P1s estão em linhas alteradas...
✅ Todas as violações P1 estão fora das linhas alteradas → merge permitido
🏁 Análise de CodeNarc concluída com sucesso.
```

https://github.com/asaasdev/asaas/pull/56274

https://github.com/asaasdev/asaas/actions/runs/21645188804/job/62395693545

<img width="2143" height="474" alt="image" src="https://github.com/user-attachments/assets/079b48eb-a562-40ce-8c98-cbd90157a91b" />


### Validação de retrocompatibilidade

- [x] Não há impacto de retrocompatibilidade - mudança isolada no script do CodeNarc Action, token já estava disponível